### PR TITLE
Introduce KODDI_ENV

### DIFF
--- a/docker/runit/service/spark/run
+++ b/docker/runit/service/spark/run
@@ -26,7 +26,7 @@ function export_daemon_opts() {
 
 function set_log_level() {
     sed "s,<LOG_LEVEL>,${SPARK_LOG_LEVEL}," \
-        /opt/spark/dist/conf/log4j.properties.template >/opt/spark/dist/conf/log4j.properties
+        /opt/spark/dist/conf/log4j.properties.template > /opt/spark/dist/conf/log4j.properties
 }
 
 function add_if_non_empty() {
@@ -68,9 +68,8 @@ exec /opt/spark/dist/bin/spark-submit \
     --conf spark.driver.port="${DISPATCHER_PORT}"
     --conf spark.ui.port="${DISPATCHER_UI_PORT}" \
     --master "mesos://zk://${ZK}/mesos" \
-    --conf spark.host="${HOST}" \
     --name "${DCOS_SERVICE_NAME}" \
     --conf spark.ssl.noCertVerification=true \
     --conf spark.mesos.executor.docker.image=${SPARK_DOCKER_IMAGE} \
     --conf spark.executor.home=/opt/spark/dist \
-    /mnt/mesos/sandbox/${KODDI_STREAM_JAR} dev
+    /mnt/mesos/sandbox/${KODDI_STREAM_JAR} ${KODDI_ENV}

--- a/marathon/spark-streaming-sample.json
+++ b/marathon/spark-streaming-sample.json
@@ -23,7 +23,8 @@
     "SPARK_DOCKER_IMAGE": "koddidev/spark:streaming-2.1.1-hadoop-2.8",
     "KODDI_STREAM_JAR": "koddi-etl-spark-streaming.jar",
     "SPARK_LOG_LEVEL": "INFO",
-    "KODDI_STREAM_CLASS": "com.koddi.etl.spark.streaming.LabelStream"
+    "KODDI_STREAM_CLASS": "com.koddi.etl.spark.streaming.LabelStream",
+    "KODDI_ENV": "dev"
   },
   "healthChecks": [
     {


### PR DESCRIPTION
Allows us to configure different environments for the streaming job (e.g. dev|prod)